### PR TITLE
markupsafe==2.0.1 added to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 wheel
 Flask==1.1.4
 Flask-Sockets
+markupsafe==2.0.1


### PR DESCRIPTION
markupsafe==2.0.1 added to requirements.txt. 

Markupsafe depricated soft_unicode from version 2.1.0 onwards. This results in the following error while running 'python3 main.py':
ImportError: cannot import name 'soft_unicode' from 'markupsafe'

By installing the last version that still uses soft_unicode (version 2.0.1) the error does not occur anymore.
